### PR TITLE
[Mellanox] Update SKUs to enable SDK dumps (#7708)

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2010.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2100.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2410.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_8x50g_28x100g.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_8x100g_40x50g_8x10g.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_48x50g_8x100g.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2740.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3420.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3700.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3700c.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_112x50g_8x100g.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_24x50g_52x100g.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_1x10g_28x50g_49x100g.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_28x50g_52x100g.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600C.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600C.xml
 SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600c_112x50g_8x100g.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4700.xml
+SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
+SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4800-r0/ACS-MSN4800/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4800-r0/ACS-MSN4800/sai.profile
@@ -1,3 +1,3 @@
-SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4410.xml
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4800.xml
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10


### PR DESCRIPTION
- Why I did it
To create SDK dump on Mellanox devices when SDK event has occurred.

- How I did it
Set the SKUs keys needed to initialize the feature in SAI.

- How to verify it
Simulate SDK event and check that dump is created in the expected path.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

