### PR TITLE
[YANG] Update range of supported port speeds to support 800G ports

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -24,6 +24,13 @@
         "eStrKey" : "Pattern",
         "eStr": ["on|off"]
     },
+    "PORT_VALID_SPEEDS_TEST_1": {
+        "desc": "PORT_VALID_SPEEDS_TEST_1 no failure."
+    },
+    "PORT_INVALID_SPEEDS_TEST_1": {
+        "desc": "PORT_INVALID_SPEEDS_TEST_1 InvalidValue condition failure.",
+        "eStr": ["pattern", "does not satisfy"]
+    },
     "PORT_VALID_ADVSPEEDS_TEST_1": {
         "desc": "PORT_VALID_ADVSPEEDS_TEST_1 no failure."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -90,6 +90,40 @@
         }
     },
 
+    "PORT_VALID_SPEEDS_TEST_1": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 800000,
+                        "autoneg": "on",
+                        "adv_speeds": [400000, 800000]
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_SPEEDS_TEST_1": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 900000,
+                        "autoneg": "on",
+                        "adv_speeds": [25000,40000]
+                    }
+                ]
+            }
+        }
+    },
+
     "PORT_VALID_ADVSPEEDS_TEST_1": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
@@ -118,6 +152,23 @@
                         "speed": 25000,
                         "autoneg": "on",
                         "adv_speeds": ["all"]
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_VALID_ADVSPEEDS_TEST_3": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "autoneg": "on",
+                        "adv_speeds": [25000,800000]
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -61,7 +61,7 @@ module sonic-port{
 				leaf speed {
 					mandatory true;
 					type uint32 {
-						range 1..400000;
+						range 1..800000;
 					}
 				}
 
@@ -78,7 +78,7 @@ module sonic-port{
 					
 					type union {
 						type uint32 {
-							range 1..400000;
+							range 1..800000;
 						}
 						type string {
 							pattern "all";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

