### PR TITLE
[NVIDIA] Log FW Update error

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -40,6 +40,7 @@ declare -rA FW_FILE_MAP=( \
 )
 
 IMAGE_UPGRADE="${NO_PARAM}"
+SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 
 function PrintHelp() {
@@ -48,7 +49,8 @@ function PrintHelp() {
     echo
     echo "OPTIONS:"
     echo "  -u, --upgrade  Upgrade ASIC firmware using next boot image (useful after SONiC-To-SONiC update)"
-    echo "  -v, --verbose  Verbose mode"
+    echo "  -s, --syslog   Use syslog logger (enabled when -u|--upgrade)"
+    echo "  -v, --verbose  Verbose mode (enabled when -u|--upgrade)"
     echo "  -h, --help     Print help"
     echo
     echo "Examples:"
@@ -63,9 +65,13 @@ function ParseArguments() {
         case "$1" in
             -u|--upgrade)
                 IMAGE_UPGRADE="${YES_PARAM}"
+                SYSLOG_LOGGER="${YES_PARAM}"
             ;;
             -v|--verbose)
                 VERBOSE_LEVEL="${VERBOSE_MAX}"
+            ;;
+            -s|--syslog)
+                SYSLOG_LOGGER="${YES_PARAM}"
             ;;
             -h|--help)
                 PrintHelp
@@ -79,6 +85,11 @@ function ParseArguments() {
 function LogError() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_ERROR}" ]]; then
         echo "ERROR: $*"
+        logger -p "ERROR" -t "${SCRIPT_NAME}" "$*"
+    fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "ERROR" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -86,17 +97,30 @@ function LogWarning() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_WARNING}" ]]; then
         echo "WARNING: $*"
     fi
+
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "WARNING" -t "${SCRIPT_NAME}" "$*"
+    fi
 }
 
 function LogNotice() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_NOTICE}" ]]; then
         echo "NOTICE: $*"
     fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "NOTICE" -t "${SCRIPT_NAME}" "$*"
+    fi
 }
 
 function LogInfo() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_INFO}" ]]; then
         echo "INFO: $*"
+    fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "INFO" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -186,6 +210,23 @@ function RunCmd() {
     fi
 }
 
+function RunFwUpdateCmd() {
+    local ERROR_CODE="${EXIT_SUCCESS}"
+    local COMMAND="${BURN_CMD} $@"
+
+    if [[ "${VERBOSE_LEVEL}" -eq "${VERBOSE_MAX}" ]]; then
+        output=$(eval "${COMMAND}")
+    else
+        output=$(eval "${COMMAND}") >/dev/null 2>&1
+    fi
+
+    ERROR_CODE="$?"
+    if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        failure_msg="${output#*Fail : }"
+        ExitFailure "FW Update command: ${COMMAND} failed with error: ${failure_msg}"
+    fi
+}
+
 function UpgradeFW() {
     local -r _FS_MOUNTPOINT="$1"
 
@@ -229,9 +270,9 @@ function UpgradeFW() {
         local -r _MST_DEVICE="$(GetMstDevice)"
         if [[ "${_MST_DEVICE}" = "${UNKN_MST}" ]]; then
             LogWarning "could not find fastest mst device, using default device"
-            RunCmd "${BURN_CMD} -i ${_FW_FILE}"
+            RunFwUpdateCmd "-i ${_FW_FILE}"
         else
-            RunCmd "${BURN_CMD} -d ${_MST_DEVICE} -i ${_FW_FILE}"
+            RunFwUpdateCmd "-d ${_MST_DEVICE} -i ${_FW_FILE}"
         fi
     fi
 }

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -98,7 +98,6 @@ function LogWarning() {
         echo "WARNING: $*"
     fi
 
-
     if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
         logger -p "WARNING" -t "${SCRIPT_NAME}" "$*"
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To have information about the cause of FW update failure in the log.

#### How I did it
In case the FW update has failed the update tool will give the cause of the failure in the output in the last line, starting with "Fail".
When running the tool, in case of a failed update, we will parse the output to retrieve the cause and log it.
```
Device #1:
 ----------
 
 Device Type:      ConnectX6DX
   Part Number:      MCX623106AN-CDA_Ax
   Description:      ConnectX-6 Dx EN adapter card; 100GbE; Dual-port QSFP56; PCIe 4.0/3.0 x16;
   PSID:             MT_0000000359
   PCI Device Name:  /dev/mst/mt4125_pciconf0
   Base GUID:        0c42a103007d22d4
   Base MAC:         0c42a17d22d4
   Versions:         Current        Available     
      FW             22.32.0498     22.32.0498    
      PXE            3.6.0500       3.6.0500      
      UEFI           14.25.0015     14.25.0015    
 
 Status:           Forced update required
 
---------
 Found 1 device(s) requiring firmware update...
 
Device #1: Updating FW ...     
 FSMST_INITIALIZE -   OK          
 Writing Boot image component -   OK          
 Fail : The Digest in the signature is wrong
```

#### How to verify it
Create a scenario where FW update fails (i.e. corrupted FW) and use the mlnx-fw-update script to try to update the FW.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

