### PR TITLE
[Mellanox] Integrate HW-MGMT 7.0040.2000 Changes

### DIFF
--- a/platform/mellanox/hw-management.mk
+++ b/platform/mellanox/hw-management.mk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/hw-management.mk
+++ b/platform/mellanox/hw-management.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 #
 # Mellanox HW Management
 
-MLNX_HW_MANAGEMENT_VERSION = 7.0040.1011
+MLNX_HW_MANAGEMENT_VERSION = 7.0040.2000
 
 export MLNX_HW_MANAGEMENT_VERSION
 

--- a/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
+++ b/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
@@ -1,7 +1,7 @@
-From 5a7bf8934772b94a2414f54cb3e343d0d1d81efd Mon Sep 17 00:00:00 2001
-From: keboliu <kebol@mellanox.com>
-Date: Fri, 15 Jan 2021 14:41:16 +0800
-Subject: [PATCH 1/3] Make SONiC determine-reboot-cause service start after
+From e588b87a2e80de284ea6e63563e27684acb2f56e Mon Sep 17 00:00:00 2001
+From: davidza <davidza@nvidia.com>
+Date: Tue, 15 Oct 2024 09:44:05 +0300
+Subject: [PATCH 1/3] Make SONiC determine-reboot-cause service start after 
  hw-mgmt service
 
 Signed-off-by: Kebo Liu <kebol@nvidia.com>
@@ -10,17 +10,17 @@ Signed-off-by: Kebo Liu <kebol@nvidia.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
-index 8bdcaef5..1c25ffb2 100755
+index 4bc1780e..1a50dc3c 100755
 --- a/debian/hw-management.hw-management.service
 +++ b/debian/hw-management.hw-management.service
-@@ -1,6 +1,7 @@
- [Unit]
+@@ -2,6 +2,7 @@
  Description=Chassis HW management service of Mellanox systems
  Documentation=man:hw-management.service(8)
+ Wants=hw-management-sync.service
 +Before=determine-reboot-cause.service
  
  [Service]
  Type=oneshot
 -- 
-2.30.2
+2.34.1
 

--- a/platform/mellanox/hw-management/0003-Make-system-health-service-starts-after-hw-managemen.patch
+++ b/platform/mellanox/hw-management/0003-Make-system-health-service-starts-after-hw-managemen.patch
@@ -1,7 +1,7 @@
-From e45320c61765b07f5d73f6c207f9f1d3b4d21721 Mon Sep 17 00:00:00 2001
-From: Stephen Sun <stephens@nvidia.com>
-Date: Mon, 28 Nov 2022 03:55:14 +0000
-Subject: [PATCH 3/3] Make system-health service starts after hw-management to
+From 69d083e05e39dc82567a338a59a2cefdcd022034 Mon Sep 17 00:00:00 2001
+From: davidza <davidza@nvidia.com>
+Date: Tue, 15 Oct 2024 09:51:11 +0300
+Subject: [PATCH 3/3] Make system-health service starts after hw-management to 
  avoid failures
 
 On SN2410, it can fail to read the file led_status_capability if it starts from ONIE
@@ -12,18 +12,18 @@ Signed-off-by: Stephen Sun <stephens@nvidia.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
-index 1c25ffb2..639bd3cd 100755
+index 1a50dc3c..8a5c0423 100755
 --- a/debian/hw-management.hw-management.service
 +++ b/debian/hw-management.hw-management.service
-@@ -1,7 +1,7 @@
- [Unit]
+@@ -2,7 +2,7 @@
  Description=Chassis HW management service of Mellanox systems
  Documentation=man:hw-management.service(8)
+ Wants=hw-management-sync.service
 -Before=determine-reboot-cause.service
 +Before=determine-reboot-cause.service system-health.service watchdog-control.service
  
  [Service]
  Type=oneshot
 -- 
-2.30.2
+2.34.1
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Integrate HW-MGMT 7.0040.2000 Changes

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Run make integrate-mlnx-hw-mgmt

#### How to verify it
Build an image and run tests from "sonic-mgmt".

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

