### PR TITLE
[lldp] Add check for hostname in lldpmgrd

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -81,6 +81,10 @@ class LldpManager(daemon_base.DaemonBase):
         self.port_init_done = False
 
     def update_hostname(self, hostname):
+        if not hostname:
+            self.log_error("Hostname is not defined")
+            sys.exit(1)
+
         cmd = ["lldpcli", "configure", "system", "hostname", hostname]
         self.log_debug("Running command: '{}'".format(cmd))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When a switch run with a config db that is missing the key hostname from the DEVICE_METADATA, exception is thrown, which isn't an user friendly.

Before:
```
2025 Mar 25 15:43:06.091724 sonic-switch INFO lldp#supervisord 2025-03-25 15:43:06,091 INFO spawned: 'lldpmgrd' with pid 38
2025 Mar 25 15:43:06.415066 sonic-switch INFO lldp#supervisord: lldpmgrd Traceback (most recent call last):
2025 Mar 25 15:43:06.415066 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 370, in <module>
2025 Mar 25 15:43:06.415099 sonic-switch INFO lldp#supervisord: lldpmgrd     main()
2025 Mar 25 15:43:06.415099 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 352, in main
2025 Mar 25 15:43:06.415167 sonic-switch INFO lldp#supervisord: lldpmgrd     lldpmgr.run()
2025 Mar 25 15:43:06.415231 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 320, in run
2025 Mar 25 15:43:06.415289 sonic-switch INFO lldp#supervisord: lldpmgrd     self.lldp_process_device_table_event(op, dict(fvp), key)
2025 Mar 25 15:43:06.415349 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 254, in lldp_process_device_table_event
2025 Mar 25 15:43:06.415407 sonic-switch INFO lldp#supervisord: lldpmgrd     self.update_hostname(hostname)
2025 Mar 25 15:43:06.415415 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 87, in update_hostname
2025 Mar 25 15:43:06.415474 sonic-switch INFO lldp#supervisord: lldpmgrd     proc = subprocess.Popen(cmd,stdout=subprocess.PIPE, stderr=subprocess.PIPE)
2025 Mar 25 15:43:06.415534 sonic-switch INFO lldp#supervisord: lldpmgrd            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025 Mar 25 15:43:06.415543 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
2025 Mar 25 15:43:06.415719 sonic-switch INFO lldp#supervisord: lldpmgrd     self._execute_child(args, executable, preexec_fn, close_fds,
2025 Mar 25 15:43:06.415719 sonic-switch INFO lldp#supervisord: lldpmgrd   File "/usr/lib/python3.11/subprocess.py", line 1834, in _execute_child
2025 Mar 25 15:43:06.416058 sonic-switch INFO lldp#supervisord: lldpmgrd     self.pid = _fork_exec(
2025 Mar 25 15:43:06.416058 sonic-switch INFO lldp#supervisord: lldpmgrd                ^^^^^^^^^^^
2025 Mar 25 15:43:06.416058 sonic-switch INFO lldp#supervisord: lldpmgrd TypeError: expected str, bytes or os.PathLike object, not NoneType
2025 Mar 25 15:43:06.466073 sonic-switch INFO lldp#supervisord 2025-03-25 15:43:06,465 WARN exited: lldpmgrd (exit status 1; not expected)

```
After:
`2025 Mar 26 09:36:58.109307 sonic-switch ERR lldp#lldpmgrd[733]: Hostname is not defined
`


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a check the make sure that hostname exists and if not, print a user friendly error instead of the traceback.

#### How to verify it
Remove the hostname configuration and start lldp docker.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

