### PR TITLE
[Mellanox]Add option to build using local SAI

### DIFF
--- a/platform/mellanox/mlnx-sai.mk
+++ b/platform/mellanox/mlnx-sai.mk
@@ -9,13 +9,17 @@ MLNX_SAI_DEB_VERSION = $(subst -,.,$(subst _,.,$(MLNX_SAI_VERSION)))
 # Place here URL where SAI sources exist
 MLNX_SAI_SOURCE_BASE_URL = 
 
-ifneq ($(MLNX_SAI_SOURCE_BASE_URL), )
-SAI_FROM_SRC = y
-else
-SAI_FROM_SRC = n
-endif
+# Optional local file path. If set, it will be used instead of downloading from the remote server.
+# Note: When using a local SAI file, DOCKER_BUILDER_USER_MOUNT must also be configured to ensure 
+# the file is mounted inside the docker build environment.
+# Example:
+# DOCKER_BUILDER_USER_MOUNT = /auto/local_build:/auto/local_build:rslave
+MLNX_LOCAL_SAI_FILE ?= 
 
-export MLNX_SAI_VERSION MLNX_SAI_SOURCE_BASE_URL
+# Set SAI_FROM_SRC based on source availability
+SAI_FROM_SRC = $(if $(or $(MLNX_SAI_SOURCE_BASE_URL),$(MLNX_LOCAL_SAI_FILE)),y,n)
+
+export MLNX_SAI_VERSION MLNX_SAI_SOURCE_BASE_URL MLNX_LOCAL_SAI_FILE
 
 MLNX_SAI = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
 $(MLNX_SAI)_SRC_PATH = $(PLATFORM_PATH)/mlnx-sai

--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -7,7 +7,12 @@ DERIVED_TARGETS = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf mlnx_sai
-	wget -c $(MLNX_SAI_SOURCE_BASE_URL)/$(MLNX_SAI_VERSION).tar.gz -O - | tar -xz
+	if [ -n "$(MLNX_LOCAL_SAI_FILE)" ] && [ -f "$(MLNX_LOCAL_SAI_FILE)" ]; then
+		echo "Using local SAI file: $(MLNX_LOCAL_SAI_FILE)"
+		tar -xzf $(MLNX_LOCAL_SAI_FILE)
+	else
+		wget -c $(MLNX_SAI_SOURCE_BASE_URL)/$(MLNX_SAI_VERSION).tar.gz -O - | tar -xz
+	fi
 	pushd mlnx_sai
 
 	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG"' -us -uc -d -b


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

