### PR TITLE
[Mellanox] fix CPLD install for SPC1 vs later Spectrum

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -752,7 +752,12 @@ class ComponentCPLD(Component):
     CPLD_PART_NUMBER_DEFAULT = '0'
     CPLD_VERSION_MINOR_DEFAULT = '0'
 
-    CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--dev', '', '--print-progress', '']
+    # Same ASIC type detection as syncd (sonic_debian_extension installs this path).
+    ASIC_DETECT_SCRIPT = '/usr/bin/asic_detect/asic_detect.sh'
+
+    CPLD_FIRMWARE_UPDATE_COMMAND_SPC1 = ['cpldupdate', '--dev', '', '--print-progress', '']
+    # GPIO path does not take an MST device; image at [3]
+    CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--gpio', '--print-progress', '']
 
     def __init__(self, idx):
         super(ComponentCPLD, self).__init__()
@@ -777,16 +782,41 @@ class ComponentCPLD(Component):
 
         return mst_dev_list[0]
 
+    @classmethod
+    def _is_spc1_asic(cls):
+        """
+        True if this system has a Spectrum-1 ASIC. SPC1 CPLD programming uses
+        cpldupdate --dev <mst>; newer Spectrum devices use --gpio.
+        Uses platform/mellanox/asic_detect/asic_detect.sh (stdout 'spc1'); the script may
+        exit non-zero for unknown ASIC — we only compare stdout.
+        """
+        if not os.path.isfile(cls.ASIC_DETECT_SCRIPT):
+            return False
+        try:
+            proc = subprocess.run(
+                [cls.ASIC_DETECT_SCRIPT],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                universal_newlines=True,
+                timeout=30)
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return proc.stdout.strip() == 'spc1'
+
     def _install_firmware(self, image_path):
         if not self._check_file_validity(image_path):
             return False
 
-        mst_dev = self.__get_mst_device()
-        if mst_dev is None:
-            return False
-        self.CPLD_FIRMWARE_UPDATE_COMMAND[2] = mst_dev
-        self.CPLD_FIRMWARE_UPDATE_COMMAND[4] = image_path
-        cmd = self.CPLD_FIRMWARE_UPDATE_COMMAND
+        if self._is_spc1_asic():
+            mst_dev = self.__get_mst_device()
+            if mst_dev is None:
+                return False
+            cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND_SPC1)
+            cmd[2] = mst_dev
+            cmd[4] = image_path
+        else:
+            cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND)
+            cmd[3] = image_path
 
         try:
             print("INFO: Installing {} firmware update: path={}".format(self.name, image_path))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -756,7 +756,6 @@ class ComponentCPLD(Component):
     ASIC_DETECT_SCRIPT = '/usr/bin/asic_detect/asic_detect.sh'
 
     CPLD_FIRMWARE_UPDATE_COMMAND_SPC1 = ['cpldupdate', '--dev', '', '--print-progress', '']
-    # GPIO path does not take an MST device; image at [3]
     CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--gpio', '--print-progress', '']
 
     def __init__(self, idx):

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -207,14 +208,16 @@ class TestComponent:
         with pytest.raises(RuntimeError):
             c.get_firmware_version()
 
+    @mock.patch('sonic_platform.component.ComponentCPLD._is_spc1_asic')
     @mock.patch('sonic_platform.component.MPFAManager.cleanup', mock.MagicMock())
     @mock.patch('sonic_platform.component.MPFAManager.extract', mock.MagicMock())
     @mock.patch('sonic_platform.component.subprocess.check_call')
     @mock.patch('sonic_platform.component.MPFAManager.get_path')
     @mock.patch('sonic_platform.component.MPFAManager.get_metadata')
     @mock.patch('sonic_platform.component.os.path.exists')
-    def test_cpld_component(self, mock_exists, mock_get_meta_data, mock_get_path, mock_check_call):
+    def test_cpld_component(self, mock_exists, mock_get_meta_data, mock_get_path, mock_check_call, mock_is_spc1):
         c = ComponentCPLD(1)
+        mock_is_spc1.return_value = True
         c._read_generic_file = mock.MagicMock(side_effect=[None, '1', None])
         assert c.get_firmware_version() == 'CPLD000000_REV0100'
 
@@ -239,6 +242,9 @@ class TestComponent:
         assert not c._install_firmware('')
         c._ComponentCPLD__get_mst_device = mock.MagicMock(return_value='some dev')
         assert c._install_firmware('')
+        mock_check_call.assert_called_once_with(
+            ['cpldupdate', '--dev', 'some dev', '--print-progress', ''],
+            universal_newlines=True)
         mock_check_call.side_effect = subprocess.CalledProcessError(1, None)
         assert not c._install_firmware('')
 
@@ -280,6 +286,27 @@ class TestComponent:
         assert c.auto_update_firmware('', 'cold') == FW_AUTO_ERR_UNKNOWN
         c.install_firmware = mock.MagicMock(return_value=True)
         assert c.auto_update_firmware('', 'cold') == FW_AUTO_SCHEDULED
+
+    @mock.patch('sonic_platform.component.ComponentCPLD._is_spc1_asic')
+    @mock.patch('sonic_platform.component.subprocess.check_call')
+    def test_cpld_component_install_non_spc1(self, mock_check_call, mock_is_spc1):
+        """Non-SPC1 CPLD component install: GPIO cpldupdate path, no MST device."""
+        c = ComponentCPLD(1)
+        mock_is_spc1.return_value = False
+        c._check_file_validity = mock.MagicMock(return_value=True)
+        c._ComponentCPLD__get_mst_device = mock.MagicMock(return_value=None)
+        install_path = '/tmp/test_cpld.vme'
+
+        assert c._install_firmware(install_path)
+        c._ComponentCPLD__get_mst_device.assert_not_called()
+        mock_check_call.assert_called_once_with(
+            ['cpldupdate', '--gpio', '--print-progress', install_path],
+            universal_newlines=True)
+
+        mock_check_call.reset_mock()
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, None)
+        assert not c._install_firmware(install_path)
+        c._ComponentCPLD__get_mst_device.assert_not_called()
 
     @mock.patch('sonic_platform.component.ComponentCPLD._read_generic_file', mock.MagicMock(return_value='3'))
     def test_cpld_get_component_list(self):


### PR DESCRIPTION
Detect Spectrum-1 with /usr/bin/asic_detect/asic_detect.sh. SPC1 keeps cpldupdate --dev <mst>; non-SPC1 uses --gpio with only the image path and no MST device.

Tests: mock _is_spc1_asic in test_cpld_component for the SPC1 path; add test_cpld_component_install_non_spc1 for the GPIO path.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The CPLD firmware install command used a single cpldupdate --dev <mst> invocation for all Spectrum platforms. Spectrum-2 and later (SPC2+) the preferred method is using gpio. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a _is_spc1_asic() class method to ComponentCPLD that runs /usr/bin/asic_detect/asic_detect.sh (the same detection script used by syncd) and checks whether stdout is spc1. In _install_firmware(), the method now branches on this result:

- SPC1: uses cpldupdate --dev <mst_device> --print-progress <image> (existing behavior)
- Non-SPC1: uses cpldupdate --gpio --print-progress <image>

#### How to verify it
Run the unit tests: pytest platform/mellanox/mlnx-platform-api/tests/test_component.py -v -k cpld
- test_cpld_component - exercises the SPC1 path (mocked _is_spc1_asic returns True), verifies cpldupdate --dev is called.
- test_cpld_component_install_non_spc1 - exercises the GPIO path (mocked _is_spc1_asic returns False), verifies cpldupdate --gpio is called.

On a physical SPC1 system, trigger CPLD install and confirm cpldupdate --dev <mst> is used.
On a non-SPC1 system, trigger CPLD install and confirm cpldupdate --gpio is used.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

